### PR TITLE
Add base URL for portfolio

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/portfolio/',
 })


### PR DESCRIPTION
This pull request adds a base URL for the portfolio project. The base URL is set to '/portfolio/' in the Vite configuration file. This change ensures that all the project's routes are relative to the '/portfolio/' path.