### PR TITLE
Add dark mode support to the navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,7 +63,7 @@ const config = {
       colorMode: {
         defaultMode: 'dark',
         disableSwitch: false,
-        respectPrefersColorScheme: true,
+        // respectPrefersColorScheme: true,
       },
       navbar: {
         title: 'Bal Narendra Sapa | Portfolio',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -60,6 +60,11 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       image: 'img/docusaurus-social-card.jpg',
+      colorMode: {
+        defaultMode: 'dark',
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
       navbar: {
         title: 'Bal Narendra Sapa | Portfolio',
         logo: {


### PR DESCRIPTION
This pull request adds dark mode support to the navbar by modifying the theme configuration. It removes the user colormode overrider and adds a new colorMode option with a defaultMode of 'dark' and disableSwitch set to false.